### PR TITLE
refactor(profiles): extract profile settings creation into separate f…

### DIFF
--- a/src/cli/platforms.ts
+++ b/src/cli/platforms.ts
@@ -32,6 +32,8 @@ export function getModrinthProfile(
 			.get(profileName) as ProfileData | undefined;
 
 		return data ?? null;
+	} catch {
+		return null;
 	} finally {
 		db.close();
 	}

--- a/src/cli/platforms.ts
+++ b/src/cli/platforms.ts
@@ -1,0 +1,38 @@
+import { Database } from 'bun:sqlite';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface ProfileData {
+	game_version: string | null;
+	mod_loader: string | null;
+	mod_loader_version: string | null;
+	override_mc_memory_max: string | null;
+	icon_path: string | null;
+}
+
+export function getModrinthProfile(
+	profilesDirectory: string,
+	profileName: string
+): ProfileData | null {
+	const dbPath = resolve(`${profilesDirectory}/../app.db`);
+	if (!existsSync(dbPath)) return null;
+
+	const db = new Database(dbPath);
+	try {
+		const data = db
+			.prepare(`
+            SELECT 
+                game_version,
+                mod_loader,
+                mod_loader_version,
+                override_mc_memory_max,
+                icon_path 
+            FROM profiles 
+            WHERE path=? LIMIT 1`)
+			.get(profileName) as ProfileData | undefined;
+
+		return data ?? null;
+	} finally {
+		db.close();
+	}
+}

--- a/src/cli/profiles.ts
+++ b/src/cli/profiles.ts
@@ -116,6 +116,16 @@ export async function createNewProfile(
 	return profileName;
 }
 
+/**
+ * Creates profile settings for a given profile directory.
+ *
+ * @param directory - The base directory where profiles are stored
+ * @param profile - The name of the profile to create
+ * @param loader - The type of mod loader to use
+ * @param version - The Minecraft version
+ * @param loaderVersion - The version of the mod loader
+ * @param ram - The RAM allocation for the profile
+ */
 export async function createProfileSettings(
 	directory: string,
 	profile: string,

--- a/src/cli/profiles.ts
+++ b/src/cli/profiles.ts
@@ -104,7 +104,27 @@ export async function createNewProfile(
 
 	if (!confirmed) return;
 
-	const profilePath = join(settings.ProfilesDirectory, profileName);
+	await createProfileSettings(
+		settings.ProfilesDirectory,
+		profileName,
+		loader,
+		version,
+		loaderVersion || '',
+		ram
+	);
+
+	return profileName;
+}
+
+export async function createProfileSettings(
+	directory: string,
+	profile: string,
+	loader: LoaderType,
+	version: string,
+	loaderVersion: string,
+	ram: string
+) {
+	const profilePath = join(directory, profile);
 	mkdirSync(profilePath, { recursive: true });
 	let loaderManifest: string | undefined;
 	if (loader === 'fabric') {
@@ -134,5 +154,4 @@ export async function createNewProfile(
 		RAM: ram,
 	};
 	saveIniFile(profileSettings, join(profilePath, 'profile-settings.ini'));
-	return profileName;
 }

--- a/src/cli/settings.ts
+++ b/src/cli/settings.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import { note, spinner, text } from '@clack/prompts';
-import { createNewProfile } from './profiles.ts';
-import type { LauncherSettings, ProfileSettings } from './types.ts';
+import { spinner, text } from '@clack/prompts';
+import { getModrinthProfile } from './platforms.ts';
+import { createNewProfile, createProfileSettings } from './profiles.ts';
+import type { LauncherSettings, LoaderType, ProfileSettings } from './types.ts';
 import { readIniFile, saveIniFile } from './utils/ini.ts';
 
 const USERNAME = process.env.USERNAME || 'Player';
@@ -79,7 +80,25 @@ export async function getProfileSettings(
 	const profilePath = join(settings.ProfilesDirectory, profile);
 	const profileSettingsPath = join(profilePath, 'profile-settings.ini');
 	while (!existsSync(profileSettingsPath)) {
-		note(`Profile settings not found at ${profileSettingsPath}`);
+		if (profileSettingsPath.includes('ModrinthApp')) {
+			const modrinthProfile = getModrinthProfile(
+				settings.ProfilesDirectory,
+				profile
+			);
+			if (modrinthProfile) {
+				await createProfileSettings(
+					settings.ProfilesDirectory,
+					profile,
+					(modrinthProfile.mod_loader || 'fabric') as LoaderType,
+					modrinthProfile.game_version || '',
+					modrinthProfile.mod_loader_version || '',
+					modrinthProfile.override_mc_memory_max || '4'
+				);
+
+				continue;
+			}
+		}
+
 		await createNewProfile(settings, profile);
 	}
 	return readIniFile<ProfileSettings>(profileSettingsPath);

--- a/src/cli/settings.ts
+++ b/src/cli/settings.ts
@@ -79,26 +79,29 @@ export async function getProfileSettings(
 ) {
 	const profilePath = join(settings.ProfilesDirectory, profile);
 	const profileSettingsPath = join(profilePath, 'profile-settings.ini');
-	while (!existsSync(profileSettingsPath)) {
-		if (profileSettingsPath.includes('ModrinthApp')) {
-			const modrinthProfile = getModrinthProfile(
+
+	if (existsSync(profileSettingsPath)) {
+		return readIniFile<ProfileSettings>(profileSettingsPath);
+	}
+
+	if (profileSettingsPath.includes('ModrinthApp')) {
+		const modrinthProfile = getModrinthProfile(
+			settings.ProfilesDirectory,
+			profile
+		);
+		if (modrinthProfile?.game_version) {
+			await createProfileSettings(
 				settings.ProfilesDirectory,
-				profile
+				profile,
+				(modrinthProfile.mod_loader || 'fabric') as LoaderType,
+				modrinthProfile.game_version,
+				modrinthProfile.mod_loader_version || '',
+				modrinthProfile.override_mc_memory_max || '4'
 			);
-			if (modrinthProfile) {
-				await createProfileSettings(
-					settings.ProfilesDirectory,
-					profile,
-					(modrinthProfile.mod_loader || 'fabric') as LoaderType,
-					modrinthProfile.game_version || '',
-					modrinthProfile.mod_loader_version || '',
-					modrinthProfile.override_mc_memory_max || '4'
-				);
-
-				continue;
-			}
 		}
+	}
 
+	while (!existsSync(profileSettingsPath)) {
 		await createNewProfile(settings, profile);
 	}
 	return readIniFile<ProfileSettings>(profileSettingsPath);


### PR DESCRIPTION
…unction

The `createProfileSettings` function was extracted from `createNewProfile` to improve code reusability and maintainability. This change allows the profile settings creation logic to be used in other parts of the application, such as when handling Modrinth profiles, without duplicating code. Additionally, the `getModrinthProfile` function was added to fetch profile data from the Modrinth database, enabling the launcher to support Modrinth profiles seamlessly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing and setting up profiles from ModrinthApp, allowing users to migrate their Modrinth profiles seamlessly.

- **Refactor**
  - Streamlined profile creation by introducing a helper function for profile setup, improving maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->